### PR TITLE
fix: test_render.sh 无法运行；edge-tts 词边界丢失与间歇性空音频

### DIFF
--- a/template/scripts/test_render.sh
+++ b/template/scripts/test_render.sh
@@ -5,7 +5,7 @@ ROOT=$(cd "$(dirname "$0")/.." && pwd); cd "$ROOT"
 COMP=$1; A=$2; TAG=${3:-$COMP}; B=build_dev_$TAG
 [ -n "$COMP" ] && [ -n "$A" ] || { echo "usage: test_render.sh <Comp> <start_frame> [tag]"; exit 1; }
 [ -d "$B" ] || npx remotion bundle src/index.ts --out-dir "$B" --log=error
-OUT=$(mktemp -d "${TMPDIR:-/tmp}/explainer_test_${TAG}.XXXXXX")
+OUT=$(mktemp -d "${TMPDIR:-/tmp}/explainer_test_${TAG}_XXXXXX")   # 目录名不能带点：Remotion 会把 .XXXXXX 当扩展名而拒渲
 trap 'rm -rf "$OUT"' EXIT
 time npx remotion render "$B" "$COMP" "$OUT" --sequence --image-format=jpeg --frames=$((A-1))-$((A+28)) --log=error
 ls "$OUT" | wc -l

--- a/template/scripts/tts_build.py
+++ b/template/scripts/tts_build.py
@@ -39,6 +39,7 @@ KOKORO_LANG = os.environ.get('KOKORO_LANG', 'a')       # a=American English, b=B
 KOKORO_SPEED = float(os.environ.get('KOKORO_SPEED', 1.0))
 KOKORO_SR = 24000
 CHUNK_PAD = float(os.environ.get('CHUNK_PAD', 0.06))  # 无词边界引擎：块间静音秒
+EDGE_RETRIES = int(os.environ.get('EDGE_RETRIES', 4))  # edge-tts 空音频重试次数
 GAP = int(os.environ.get('GAP', 10))          # 句间空白帧
 CHAPTER_GAP = int(os.environ.get('CHAPTER_GAP', 45))  # 章节前空白帧
 LEAD = int(os.environ.get('LEAD', 40))        # 片头静音帧
@@ -131,19 +132,34 @@ async def synth_edge(text):
     mp3 = cache_path(text, '.mp3'); js = cache_path(text, '.json')
     if os.path.exists(mp3) and os.path.exists(js):
         return mp3, json.load(open(js))
-    comm = edge_tts.Communicate(text, VOICE, rate=RATE)
+    # 微软端点会间歇性返回空音频（NoAudioReceived）：50 句的片子里随机一两句会中招，
+    # 同一句重试多半就过。不重试的话整片会在随机一句上中断。
     audio = bytearray(); words = []
-    async for ch in comm.stream():
-        if ch['type'] == 'audio':
-            audio += ch['data']
-        elif ch['type'] == 'WordBoundary':
-            words.append({'t': ch['offset'] / 1e7, 'd': ch['duration'] / 1e7, 'text': ch['text']})
+    for attempt in range(EDGE_RETRIES):
+        try:
+            comm = edge_tts.Communicate(text, VOICE, rate=RATE)
+            audio = bytearray(); words = []
+            async for ch in comm.stream():
+                if ch['type'] == 'audio':
+                    audio += ch['data']
+                elif ch['type'] == 'WordBoundary':
+                    words.append({'t': ch['offset'] / 1e7, 'd': ch['duration'] / 1e7, 'text': ch['text']})
+            if audio:
+                break
+        except Exception as e:
+            if attempt == EDGE_RETRIES - 1:
+                raise
+            print(f'  ⚠ edge-tts 第 {attempt + 1} 次失败（{type(e).__name__}），重试：{text[:16]}…')
+        await asyncio.sleep(1.5 * (attempt + 1))
+    if not audio:
+        raise SystemExit(f'edge-tts 重试 {EDGE_RETRIES} 次仍未拿到音频：{text[:30]}…')
     open(mp3, 'wb').write(audio)
     json.dump(words, open(js, 'w'), ensure_ascii=False)
     return mp3, words
 
 
 _kokoro = None
+_EDGE_NO_WB = None   # None=未探测 / True=端点不返回 WordBoundary → 退回逐块合成
 
 
 def synth_kokoro(text):
@@ -229,10 +245,29 @@ async def synth_sentence(chunks, sep=''):
     kokoro：无词边界 → 逐字幕块分别合成再拼接，块起点因此是精确的，代价是块界断句略生硬。"""
     text = sep.join(chunks)
     if ENGINE == 'edge':
-        au, words = await synth_edge(text)
-        x, lead_cut = trim_edges(decode(au))
-        dur = len(x) / SR
-        return x, chunk_starts(text, chunks, words, lead_cut, dur, sep), dur
+        global _EDGE_NO_WB
+        if _EDGE_NO_WB is None:                      # 首句探一次：端点还给不给词级边界
+            _, _probe = await synth_edge(text)
+            _EDGE_NO_WB = not _probe
+            if _EDGE_NO_WB:
+                print('⚠ 端点未返回 WordBoundary → 改用逐字幕块分别合成'
+                      '（块起点仍精确，代价是块界断句略硬；CHUNK_PAD 调块间静音）')
+        if not _EDGE_NO_WB:
+            au, words = await synth_edge(text)
+            x, lead_cut = trim_edges(decode(au))
+            dur = len(x) / SR
+            return x, chunk_starts(text, chunks, words, lead_cut, dur, sep), dur
+        pad = np.zeros(int(CHUNK_PAD * SR), dtype=np.float32)
+        parts = []; starts = []; pos = 0.0
+        for i, c in enumerate(chunks):
+            aui, _ = await synth_edge(c)
+            xi, _ = trim_edges(decode(aui))
+            if i:
+                parts.append(pad); pos += len(pad) / SR
+            starts.append(pos)
+            parts.append(xi); pos += len(xi) / SR
+        x = np.concatenate(parts) if parts else np.zeros(0, dtype=np.float32)
+        return x, starts, len(x) / SR
     pad = np.zeros(int(CHUNK_PAD * SR), dtype=np.float32)
     parts = []; starts = []; pos = 0.0
     for i, c in enumerate(chunks):


### PR DESCRIPTION
谢谢你开源这套东西。我按 SKILL.md 完整跑了一条 4 分半的中文片（Apple M5 / macOS），过程中撞到三个问题，都能稳定复现，一并修在这里。

## 1. `test_render.sh` 在任何机器上都跑不通

`mktemp -d ".../explainer_test_${TAG}.XXXXXX"` 造出的目录名总是带一个点，Remotion 的 `getOutputFilename` 会把它当成图片序列的扩展名并直接拒渲：

```
Error: The output directory of the image sequence cannot have an extension. Got: 024kyL
```

把点换成下划线即可。修复后 30 帧 3.6s 渲完。

## 2. 微软端点不再返回 `WordBoundary`（2026-09 实测）

四个音色（`YunxiNeural` / `XiaoxiaoNeural` / `YunyangNeural` / `AndrewNeural`）、中英文、单句与多句全测，`WordBoundary` 事件恒为 0，只剩 `SentenceBoundary`。edge-tts 钉在 7.2.8 也一样，是端点行为变了，不是版本问题。

后果不是报错而是**静默降级**：`chunk_starts()` 拿到空的 `words` 后，所有字幕块起点走「按字数线性插值」兜底。实测一句 8 字切成 3+5 两块时，第二块落在 f104，正是 `86 + 47×3/8` 的插值结果，而非真实发声位置。README 里「有词级边界 → 字幕节拍最准」在当前端点下已不成立。

这个 PR 的做法是：首句探一次，探到没有词边界就走 kokoro 那条已有的「逐字幕块分别合成再拼接」路径——块起点由此仍然精确，代价是块界断句略硬（`CHUNK_PAD` 可调）。端点若恢复返回词边界，行为自动回到原路径，不影响现有片子。

## 3. `NoAudioReceived` 是间歇性的

50 句的片子里随机一两句会拿到空音频，脚本直接中止。同一句单独重试 3 次全部成功，换音色、换语速也都成功，所以不是内容或参数问题。加了 4 次重试（`EDGE_RETRIES` 可调）。

顺带补一个洞：原代码在拿不到音频时会继续往下写出一个空 mp3。这里改成重试耗尽即报错，避免把坏结果当成品交付。

## 验证

- 修复 1：真实项目上跑 `test_render.sh`，修复前必报上述错误，修复后正常出 30 帧
- 修复 2：最小项目端到端跑通，兜底提示正常打印
- 修复 3：给一个不存在的音色做变异测试，确认报错退出、不写空 mp3、不生成 `audio.wav`
