### PR TITLE
fix(tts): 显式请求词边界（edge-tts 7.2.0+ 默认不给）；空音频自动重试

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Dependencies:
 brew install ffmpeg          # frame extraction / transcoding, required
 
 python3 -m venv ~/.venvs/a2e && source ~/.venvs/a2e/bin/activate
-pip install 'edge-tts==7.2.8' numpy pillow scipy   # pin edge-tts: it tracks a Microsoft endpoint and breaks across upgrades
+pip install 'edge-tts==7.2.8' numpy pillow scipy   # pin edge-tts: it tracks a Microsoft endpoint and breaks across upgrades (7.2.0+ needs word boundaries requested explicitly; the script does)
 
 # only needed for English narration (kokoro-82m runs locally)
 pip install kokoro soundfile && brew install espeak-ng

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -64,7 +64,7 @@ ln -s "$PWD/anything2explainer" ~/.codex/skills/anything2explainer    # Codex
 brew install ffmpeg          # 抽帧 / 转码，必需
 
 python3 -m venv ~/.venvs/a2e && source ~/.venvs/a2e/bin/activate
-pip install 'edge-tts==7.2.8' numpy pillow scipy   # 建议固定 edge-tts 版本：它跟着微软端点变，升级常有破坏性
+pip install 'edge-tts==7.2.8' numpy pillow scipy   # 建议固定 edge-tts 版本：它跟着微软端点变，升级常有破坏性（7.2.0 起词边界要显式请求，脚本已处理）
 
 # 只做英文片时再装（kokoro-82m 本地推理）
 pip install kokoro soundfile && brew install espeak-ng

--- a/template/scripts/test_render.sh
+++ b/template/scripts/test_render.sh
@@ -5,7 +5,7 @@ ROOT=$(cd "$(dirname "$0")/.." && pwd); cd "$ROOT"
 COMP=$1; A=$2; TAG=${3:-$COMP}; B=build_dev_$TAG
 [ -n "$COMP" ] && [ -n "$A" ] || { echo "usage: test_render.sh <Comp> <start_frame> [tag]"; exit 1; }
 [ -d "$B" ] || npx remotion bundle src/index.ts --out-dir "$B" --log=error
-OUT=$(mktemp -d "${TMPDIR:-/tmp}/explainer_test_${TAG}_XXXXXX")
+OUT=$(mktemp -d "${TMPDIR:-/tmp}/explainer_test_${TAG}_XXXXXX")   # 模板里不能带点：Remotion 会把 .XXXXXX 当成图片序列的扩展名而拒渲
 trap 'rm -rf "$OUT"' EXIT
 time npx remotion render "$B" "$COMP" "$OUT" --sequence --image-format=jpeg --frames=$((A-1))-$((A+28)) --log=error
 ls "$OUT" | wc -l

--- a/template/scripts/tts_build.py
+++ b/template/scripts/tts_build.py
@@ -18,7 +18,7 @@ TTS 引擎（`TTS_ENGINE`，默认 `auto` = 按解说词语言选；**跑之前�
            KOKORO_VOICE=am_liam（Liam，男声，与中文云希同定位）KOKORO_LANG=a KOKORO_SPEED=1.0
   kokoro 没有词边界 → 改为「逐字幕块分别合成再拼接」，块起始帧因此也是精确的（CHUNK_PAD 调块间静音）。
   用户有别的 TTS 偏好时不走本脚本：让他给成品配音 wav，按逐句/逐块时间轴手填 timeline.ts 与 subs.ts。
-其它环境变量：GAP/CHAPTER_GAP/LEAD/TAIL（帧）。
+其它环境变量：GAP/CHAPTER_GAP/LEAD/TAIL（帧）、EDGE_TRIES（edge 每句最多试几次，端点会间歇性返回空音频）。
 """
 import asyncio, hashlib, json, os, re, subprocess, sys
 import numpy as np
@@ -39,6 +39,7 @@ KOKORO_LANG = os.environ.get('KOKORO_LANG', 'a')       # a=American English, b=B
 KOKORO_SPEED = float(os.environ.get('KOKORO_SPEED', 1.0))
 KOKORO_SR = 24000
 CHUNK_PAD = float(os.environ.get('CHUNK_PAD', 0.06))  # 无词边界引擎：块间静音秒
+EDGE_TRIES = int(os.environ.get('EDGE_TRIES', 4))       # edge-tts 每句最多试几次（端点会间歇性返回空音频）
 GAP = int(os.environ.get('GAP', 10))          # 句间空白帧
 CHAPTER_GAP = int(os.environ.get('CHAPTER_GAP', 45))  # 章节前空白帧
 LEAD = int(os.environ.get('LEAD', 40))        # 片头静音帧
@@ -126,18 +127,31 @@ def write_wav(path, x, sr):
 
 
 async def synth_edge(text):
-    """edge-tts：整句合成 + 词级边界（会把 text 发送到微软云端端点）。"""
+    """edge-tts：整句合成 + 词级边界（会把 text 发送到微软云端端点）。
+    端点会间歇性返回空音频（NoAudioReceived）：50 句的片子里随机一两句中招，同一句重试多半就过，
+    所以试 EDGE_TRIES 次；试完还拿不到就报错退出，不把空 mp3 当成品往下传。"""
     import edge_tts
     mp3 = cache_path(text, '.mp3'); js = cache_path(text, '.json')
     if os.path.exists(mp3) and os.path.exists(js):
         return mp3, json.load(open(js))
-    comm = edge_tts.Communicate(text, VOICE, rate=RATE)
-    audio = bytearray(); words = []
-    async for ch in comm.stream():
-        if ch['type'] == 'audio':
-            audio += ch['data']
-        elif ch['type'] == 'WordBoundary':
-            words.append({'t': ch['offset'] / 1e7, 'd': ch['duration'] / 1e7, 'text': ch['text']})
+    for attempt in range(1, EDGE_TRIES + 1):
+        audio = bytearray(); words = []
+        try:
+            comm = edge_tts.Communicate(text, VOICE, rate=RATE)
+            async for ch in comm.stream():
+                if ch['type'] == 'audio':
+                    audio += ch['data']
+                elif ch['type'] == 'WordBoundary':
+                    words.append({'t': ch['offset'] / 1e7, 'd': ch['duration'] / 1e7, 'text': ch['text']})
+            if audio:
+                break
+            why = '端点返回空音频'
+        except Exception as e:
+            why = f'{type(e).__name__}: {e}'
+        if attempt == EDGE_TRIES:
+            raise SystemExit(f'edge-tts 试了 {EDGE_TRIES} 次仍拿不到音频（{why}）：{text[:30]}…')
+        print(f'  ⚠ edge-tts 第 {attempt} 次失败（{why}），{1.5 * attempt:.1f}s 后重试：{text[:16]}…')
+        await asyncio.sleep(1.5 * attempt)
     open(mp3, 'wb').write(audio)
     json.dump(words, open(js, 'w'), ensure_ascii=False)
     return mp3, words

--- a/template/scripts/tts_build.py
+++ b/template/scripts/tts_build.py
@@ -14,6 +14,7 @@
 
 TTS 引擎（`TTS_ENGINE`，默认 `auto` = 按解说词语言选；**跑之前先问用户有没有偏好的 TTS**，见 SKILL.md 确认点 3）：
   edge     中文默认。edge-tts 云端合成，有词级边界 → 字幕节拍最准。VOICE=zh-CN-YunxiNeural RATE=+8%
+           词边界要显式请求（boundary='WordBoundary'，7.2.0 起的默认值不给），否则字幕起点会静默退化成插值。
   kokoro   英文默认。kokoro-82m 本地推理（`pip install kokoro soundfile` + `brew install espeak-ng`）。
            KOKORO_VOICE=am_liam（Liam，男声，与中文云希同定位）KOKORO_LANG=a KOKORO_SPEED=1.0
   kokoro 没有词边界 → 改为「逐字幕块分别合成再拼接」，块起始帧因此也是精确的（CHUNK_PAD 调块间静音）。
@@ -39,7 +40,7 @@ KOKORO_LANG = os.environ.get('KOKORO_LANG', 'a')       # a=American English, b=B
 KOKORO_SPEED = float(os.environ.get('KOKORO_SPEED', 1.0))
 KOKORO_SR = 24000
 CHUNK_PAD = float(os.environ.get('CHUNK_PAD', 0.06))  # 无词边界引擎：块间静音秒
-EDGE_TRIES = int(os.environ.get('EDGE_TRIES', 4))       # edge-tts 每句最多试几次（端点会间歇性返回空音频）
+EDGE_TRIES = int(os.environ.get('EDGE_TRIES', 4))     # edge-tts 每句最多试几次（端点会间歇性返回空音频）
 GAP = int(os.environ.get('GAP', 10))          # 句间空白帧
 CHAPTER_GAP = int(os.environ.get('CHAPTER_GAP', 45))  # 章节前空白帧
 LEAD = int(os.environ.get('LEAD', 40))        # 片头静音帧
@@ -128,6 +129,8 @@ def write_wav(path, x, sr):
 
 async def synth_edge(text):
     """edge-tts：整句合成 + 词级边界（会把 text 发送到微软云端端点）。
+    boundary='WordBoundary' 必须显式传：edge-tts 7.2.0 起该参数默认 'SentenceBoundary'，
+    不传就一个 WordBoundary 事件都收不到，chunk_starts() 会静默退化成按字数插值（字幕能偏半秒）。
     端点会间歇性返回空音频（NoAudioReceived）：50 句的片子里随机一两句中招，同一句重试多半就过，
     所以试 EDGE_TRIES 次；试完还拿不到就报错退出，不把空 mp3 当成品往下传。"""
     import edge_tts
@@ -137,7 +140,7 @@ async def synth_edge(text):
     for attempt in range(1, EDGE_TRIES + 1):
         audio = bytearray(); words = []
         try:
-            comm = edge_tts.Communicate(text, VOICE, rate=RATE)
+            comm = edge_tts.Communicate(text, VOICE, rate=RATE, boundary='WordBoundary')
             async for ch in comm.stream():
                 if ch['type'] == 'audio':
                     audio += ch['data']
@@ -146,6 +149,8 @@ async def synth_edge(text):
             if audio:
                 break
             why = '端点返回空音频'
+        except TypeError:                # boundary 参数是 edge-tts 7.2.0 才有的
+            raise SystemExit("edge-tts 版本过旧：pip install 'edge-tts==7.2.8'")
         except Exception as e:
             why = f'{type(e).__name__}: {e}'
         if attempt == EDGE_TRIES:


### PR DESCRIPTION
接 #1。@DHCatLaw 报的三个问题我都复现了，两个真实存在，这里按查到的根因修掉；空音频重试直接采纳他的方案（commit 保留其 authorship），词边界那条换了修法。

## 1. 词边界丢失：根因是 edge-tts 客户端默认值，不是端点变了

`WordBoundary` 事件确实恒为 0（我本机 edge-tts 7.2.8、四个音色、中英文都复现）。但原因在客户端：**edge-tts 7.2.0（2025-08-05）给 `Communicate` 加了 `boundary` 参数，默认值是 `'SentenceBoundary'`**，请求里发出去的就是 `wordBoundaryEnabled:"false"`：

```python
# edge_tts/communicate.py:335 @ 7.2.8
boundary: Literal["WordBoundary", "SentenceBoundary"] = "SentenceBoundary",
```

7.0.2 及以前是硬编码 `wordBoundaryEnabled:"true"`。README 钉的 `edge-tts==7.2.8` 正好落在新默认值这一侧，而脚本没显式传参 —— 所以 #1 里「钉版本也一样」的观察是对的，只是那一版本身就带这个默认值。

后果不是报错而是静默降级：`chunk_starts()` 拿到空 `words` → 所有字幕块起点走「按字数线性插值」兜底。拿仓库自带 `examples/rag/narration.txt` 里的真实句子实测（`zh-CN-YunxiNeural`，`+8%`）：

```
第三|遇到不知道的问题|它不会说我不知道|而是一脸自信地编一个答案|这就是幻觉

插值（修复前）   块起始帧  0,  9, 45, 81, 134
真实发声位置     块起始帧  0,  6, 30, 76, 130
```

**最大偏 15 帧 —— 字幕整块晚半秒出**，肉眼可见。这个洞在所有 edge 引擎的成片里一直存在。

修法是显式传 `boundary='WordBoundary'`：仍然单次整句合成，韵律不动、句长不变，只是词边界回来了。相比 #1 的「退回逐块合成」，省掉了这些代价：一句 5 块要 5 次云端调用（空音频命中概率跟着涨）、块界韵律断掉、整句时长变化会让已有项目里硬编码的镜头帧全部重对位，以及文件头/README 里「有词级边界 → 字幕节拍最准」变成假话。

顺手加了一条旧版本的 `TypeError` 兜底（该参数 7.2.0 才有），报可操作的错而不是空转重试四次。

## 2. 空音频重试：采纳，收紧了几处

`NoAudioReceived` 是间歇性的（edge-tts 在 `communicate.py:561` 抛），一句失败整片就断在随机位置。每句最多试 `EDGE_TRIES` 次（默认 4），退避 1.5s / 3s / 4.5s；试完仍拿不到就报错退出，不再往下写空 mp3。

相对 #1 的实现改了：`sleep` 移进「还要再试」的分支（原版无条件执行，最后一轮空音频要白等 6 秒才退出）；「无异常但音频为空」这条路也打印原因（原版静默）；`EDGE_RETRIES` → `EDGE_TRIES`，语义是总尝试次数不是重试次数；去掉循环外那行死初始化。

## 3. mktemp 带点：`da6d892` 已修，只补注释

#1 的基线落后两个 commit。这里只留一句注释防止再改回去。

## 验证

- 词边界：中英文句子跑通，词边界事件恢复（上表右列即修复后实测值）
- 重试：`VOICE` 换成不存在的音色做变异测试 —— 逐次打印失败原因、退避重试、最后报错退出，`audio/cache` 里不留空 mp3；正常路径单次成功即 break，不引入额外等待
- 旧版本兜底：mock 掉 `Communicate` 抛 `TypeError`，确认打印可操作提示后立即退出

已知未处理：`examples/rag/timeline.md` 是在插值路径下生成的，成片已发布，这次不重新生成。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
