### PR TITLE
Linux / Raspberry Pi (ARM) support: portable sed, local ARM TTS engines, system-Chromium config

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,34 @@ pip install kokoro soundfile && brew install espeak-ng
 
 `scipy` is only used by the QC script `frame_metrics.py`. The shell scripts are zsh + Python 3, developed and verified on macOS; Linux should work, Windows is untested.
 
+### Linux / Raspberry Pi (ARM)
+
+Verified on a Raspberry Pi 5 (ARM64, Python 3.13). Three things differ from macOS:
+
+```bash
+sudo apt install zsh espeak-ng                 # scripts are #!/bin/zsh; espeak-ng for kokoro/piper G2P
+
+# Remotion has no linux-arm64 headless browser → point it at system Chromium:
+sudo apt install chromium                       # or chromium-browser
+export REMOTION_BROWSER_EXECUTABLE=/usr/bin/chromium   # read by template/remotion.config.ts (no-op on macOS)
+```
+
+**TTS on Linux/ARM.** `kokoro` (the default English engine) is hard to install on ARM/Python 3.13 (it pins an old numpy and pulls spaCy → blis, which lack aarch64 wheels). Two local engines that install cleanly instead — pass one via `TTS_ENGINE`:
+
+```bash
+# kokoro_onnx — natural voice, onnxruntime (no torch/spaCy). Download model + voices from
+#   github.com/thewh1teagle/kokoro-onnx releases (kokoro-v1.0.onnx, voices-v1.0.bin)
+pip install kokoro-onnx
+TTS_ENGINE=kokoro_onnx KOKORO_ONNX_MODEL=…/kokoro-v1.0.onnx KOKORO_ONNX_VOICES=…/voices-v1.0.bin \
+  KOKORO_ONNX_VOICE=am_michael python3 scripts/tts_build.py
+
+# piper — fastest local, robotic; a Pi-native fallback. Voice .onnx from github.com/rhasspy/piper
+pip install piper-tts
+TTS_ENGINE=piper PIPER_MODEL=…/en_US-ryan-medium.onnx python3 scripts/tts_build.py
+```
+
+The `edge` engine (natural, free, word-boundary timing) also works on Linux and needs no local model — it's a cloud call to Microsoft: `TTS_ENGINE=edge VOICE=en-US-AndrewNeural python3 scripts/tts_build.py`.
+
 ## Usage
 
 In Claude Code or Codex, just say what you want. The skill triggers itself:

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -72,6 +72,34 @@ pip install kokoro soundfile && brew install espeak-ng
 
 `scipy` 只给质检脚本 `frame_metrics.py` 用。脚本是 zsh + Python 3，在 macOS 上开发与验证；Linux 应可用，Windows 未测试。
 
+### Linux / 树莓派（ARM）
+
+已在树莓派 5（ARM64、Debian trixie、Python 3.13）上跑通。与 macOS 有三处不同：
+
+```bash
+sudo apt install zsh espeak-ng                 # 脚本是 #!/bin/zsh；espeak-ng 供 kokoro/piper 的 G2P
+
+# Remotion 没有 linux-arm64 的无头浏览器 → 指向系统 Chromium：
+sudo apt install chromium                       # 或 chromium-browser
+export REMOTION_BROWSER_EXECUTABLE=/usr/bin/chromium   # 由 template/remotion.config.ts 读取（macOS 上无副作用）
+```
+
+**Linux/ARM 上的配音。** 默认英文引擎 `kokoro` 在 ARM/Python 3.13 上很难装：它固定了旧版 numpy（无 aarch64/py3.13 轮子，只能源码编译，会失败），且依赖 spaCy → `blis`（无 aarch64 轮子、编译不过）。补了两个能干净安装的本地引擎，用 `TTS_ENGINE` 指定，二者都走既有的“逐字幕块合成”路径：
+
+```bash
+# kokoro_onnx —— 音色自然，onnxruntime（不依赖 torch/spaCy）。模型与声音库从
+#   github.com/thewh1teagle/kokoro-onnx 的 releases 下（kokoro-v1.0.onnx、voices-v1.0.bin）
+pip install kokoro-onnx
+TTS_ENGINE=kokoro_onnx KOKORO_ONNX_MODEL=…/kokoro-v1.0.onnx KOKORO_ONNX_VOICES=…/voices-v1.0.bin \
+  KOKORO_ONNX_VOICE=am_michael python3 scripts/tts_build.py
+
+# piper —— 最快的本地引擎，音色偏机械，作树莓派原生兜底。语音 .onnx 从 github.com/rhasspy/piper 下
+pip install piper-tts
+TTS_ENGINE=piper PIPER_MODEL=…/en_US-ryan-medium.onnx python3 scripts/tts_build.py
+```
+
+`edge` 引擎（自然、免费、有词级边界）在 Linux 上也能用，且不需要本地模型——它是调微软云端接口：`TTS_ENGINE=edge VOICE=en-US-AndrewNeural python3 scripts/tts_build.py`。
+
 ## 用法
 
 在 Claude Code 或 Codex 里直接说要做什么，skill 会被触发：

--- a/template/remotion.config.ts
+++ b/template/remotion.config.ts
@@ -1,0 +1,13 @@
+import {Config} from '@remotion/cli/config';
+
+// Linux / ARM (e.g. Raspberry Pi) support.
+// Chrome-for-Testing has no linux-arm64 build, so Remotion can't download a browser there.
+// Point it at a system Chromium via env, e.g.:
+//   export REMOTION_BROWSER_EXECUTABLE=/usr/bin/chromium
+// On a GPU-less headless box also set software GL (default 'swangle'); override with REMOTION_GL.
+// Both are unset on macOS / x86 → this file is a no-op and Remotion uses its own browser.
+const browser = process.env.REMOTION_BROWSER_EXECUTABLE;
+if (browser) {
+  Config.setBrowserExecutable(browser);
+  Config.setChromiumOpenGlRenderer((process.env.REMOTION_GL as never) || 'swangle');
+}

--- a/template/scripts/new_project.sh
+++ b/template/scripts/new_project.sh
@@ -13,6 +13,8 @@ case "$SLUG" in
 esac
 mkdir -p "$DEST"
 rsync -a --exclude node_modules --exclude 'build*' --exclude renders --exclude fin_frames --exclude stills --exclude 'audio/cache' "$HERE/" "$DEST/"
-sed -i '' "s/slug: 'demo'/slug: '$SLUG'/" "$DEST/src/config.ts"
+# portable in-place edit: `-i.bak` + rm works on both BSD/macOS and GNU/Linux sed
+# (BSD `sed -i ''` breaks on GNU sed, which reads '' as the script and config.ts as a file)
+sed -i.bak "s/slug: 'demo'/slug: '$SLUG'/" "$DEST/src/config.ts" && rm -f "$DEST/src/config.ts.bak"
 mkdir -p "$DEST/public/assets/$SLUG" "$DEST/script" "$DEST/research" "$DEST/qc" "$DEST/stills" "$DEST/renders"
 cd "$DEST" && npm install --silent && npx tsc --noEmit && echo "project ready: $DEST (slug=$SLUG)"

--- a/template/scripts/tts_build.py
+++ b/template/scripts/tts_build.py
@@ -18,6 +18,10 @@ TTS 引擎（`TTS_ENGINE`，默认 `auto` = 按解说词语言选；**跑之前�
   kokoro   英文默认。kokoro-82m 本地推理（`pip install kokoro soundfile` + `brew install espeak-ng`）。
            KOKORO_VOICE=am_liam（Liam，男声，与中文云希同定位）KOKORO_LANG=a KOKORO_SPEED=1.0
   kokoro 没有词边界 → 改为「逐字幕块分别合成再拼接」，块起始帧因此也是精确的（CHUNK_PAD 调块间静音）。
+  piper       Linux/ARM（含树莓派）本地配音。onnxruntime 版 VITS，无 torch/spacy。`pip install piper-tts` +
+              一个 .onnx 语音，路径经 PIPER_MODEL 传入；无词边界，同 kokoro 逐块合成。装得最快，音色一般。
+  kokoro_onnx Linux/ARM 本地配音，音色自然。onnxruntime 版 kokoro，无 torch/spacy（比 `kokoro` 引擎好装）。
+              `pip install kokoro-onnx` + 模型 KOKORO_ONNX_MODEL / 声音库 KOKORO_ONNX_VOICES；KOKORO_ONNX_VOICE 默认 am_michael。
   用户有别的 TTS 偏好时不走本脚本：让他给成品配音 wav，按逐句/逐块时间轴手填 timeline.ts 与 subs.ts。
 其它环境变量：GAP/CHAPTER_GAP/LEAD/TAIL（帧）、EDGE_TRIES（edge 每句最多试几次，端点会间歇性返回空音频）。
 """
@@ -39,6 +43,14 @@ KOKORO_VOICE = os.environ.get('KOKORO_VOICE', 'am_liam')
 KOKORO_LANG = os.environ.get('KOKORO_LANG', 'a')       # a=American English, b=British
 KOKORO_SPEED = float(os.environ.get('KOKORO_SPEED', 1.0))
 KOKORO_SR = 24000
+# piper（TTS_ENGINE=piper）：本地/ARM 友好，模型路径经环境变量传入（无默认，缺省即报错提示）
+PIPER_MODEL = os.environ.get('PIPER_MODEL', '')
+PIPER_VOICE_NAME = os.path.basename(PIPER_MODEL).replace('.onnx', '') if PIPER_MODEL else 'piper'
+# kokoro_onnx（TTS_ENGINE=kokoro_onnx）：onnxruntime 版 kokoro，无 torch/spacy
+KOKORO_ONNX_MODEL = os.environ.get('KOKORO_ONNX_MODEL', '')     # 例：kokoro-v1.0.onnx
+KOKORO_ONNX_VOICES = os.environ.get('KOKORO_ONNX_VOICES', '')  # 例：voices-v1.0.bin
+KOKORO_ONNX_VOICE = os.environ.get('KOKORO_ONNX_VOICE', 'am_michael')
+KOKORO_ONNX_LANG = os.environ.get('KOKORO_ONNX_LANG', 'en-us')
 CHUNK_PAD = float(os.environ.get('CHUNK_PAD', 0.06))  # 无词边界引擎：块间静音秒
 EDGE_TRIES = int(os.environ.get('EDGE_TRIES', 4))     # edge-tts 每句最多试几次（端点会间歇性返回空音频）
 GAP = int(os.environ.get('GAP', 10))          # 句间空白帧
@@ -47,8 +59,8 @@ LEAD = int(os.environ.get('LEAD', 40))        # 片头静音帧
 TAIL = int(os.environ.get('TAIL', 90))        # 片尾静音帧
 CACHE = f'{ROOT}/audio/cache'
 os.makedirs(CACHE, exist_ok=True)
-if ENGINE not in ('auto', 'edge', 'kokoro'):
-    raise SystemExit(f'未知 TTS_ENGINE={ENGINE}（可选 auto / edge / kokoro）')
+if ENGINE not in ('auto', 'edge', 'kokoro', 'piper', 'kokoro_onnx'):
+    raise SystemExit(f'未知 TTS_ENGINE={ENGINE}（可选 auto / edge / kokoro / piper / kokoro_onnx）')
 
 
 def parse(path):
@@ -76,7 +88,7 @@ def parse(path):
 
 
 def cache_path(text, ext):
-    sig = f'{ENGINE}|{VOICE}|{RATE}|{KOKORO_VOICE}|{KOKORO_LANG}|{KOKORO_SPEED}|{text}'
+    sig = f'{ENGINE}|{VOICE}|{RATE}|{KOKORO_VOICE}|{KOKORO_ONNX_VOICE}|{KOKORO_LANG}|{KOKORO_SPEED}|{text}'
     return f'{CACHE}/{hashlib.sha1(sig.encode()).hexdigest()[:16]}{ext}'
 
 
@@ -208,6 +220,55 @@ def synth_kokoro(text):
     return au
 
 
+_piper = None
+
+
+def synth_piper(text):
+    """piper-tts：本地推理（onnxruntime，Linux/ARM/树莓派友好，无 torch/spacy），无词边界 → 逐块合成。
+    模型原生采样率写 wav；decode() 再用 ffmpeg 重采样到 SR。需 PIPER_MODEL 指向一个 .onnx 语音。"""
+    global _piper
+    if not PIPER_MODEL:
+        raise SystemExit('TTS_ENGINE=piper 需要 PIPER_MODEL 指向一个 piper .onnx 语音'
+                         '（pip install piper-tts；语音见 github.com/rhasspy/piper voices）')
+    au = cache_path(text, '.wav')
+    if os.path.exists(au):
+        return au
+    if _piper is None:
+        try:
+            from piper import PiperVoice
+        except ImportError:
+            raise SystemExit('TTS_ENGINE=piper 需要 piper：pip install piper-tts')
+        _piper = PiperVoice.load(PIPER_MODEL)
+    import wave
+    with wave.open(au, 'wb') as w:
+        _piper.synthesize_wav(text, w)
+    return au
+
+
+_kokoro_onnx = None
+
+
+def synth_kokoro_onnx(text):
+    """kokoro-onnx：onnxruntime 版 kokoro（Linux/ARM 友好，无 torch/spacy；比 `kokoro` 引擎好装、音色自然），
+    24kHz，无词边界 → 逐块合成。需 KOKORO_ONNX_MODEL / KOKORO_ONNX_VOICES 两个模型文件。"""
+    global _kokoro_onnx
+    if not (KOKORO_ONNX_MODEL and KOKORO_ONNX_VOICES):
+        raise SystemExit('TTS_ENGINE=kokoro_onnx 需要 KOKORO_ONNX_MODEL 与 KOKORO_ONNX_VOICES'
+                         '（pip install kokoro-onnx；模型见 github.com/thewh1teagle/kokoro-onnx releases）')
+    au = cache_path(text, '.wav')
+    if os.path.exists(au):
+        return au
+    if _kokoro_onnx is None:
+        try:
+            from kokoro_onnx import Kokoro
+        except ImportError:
+            raise SystemExit('TTS_ENGINE=kokoro_onnx 需要 kokoro-onnx：pip install kokoro-onnx')
+        _kokoro_onnx = Kokoro(KOKORO_ONNX_MODEL, KOKORO_ONNX_VOICES)
+    s, sr = _kokoro_onnx.create(text, voice=KOKORO_ONNX_VOICE, speed=KOKORO_SPEED, lang=KOKORO_ONNX_LANG)
+    write_wav(au, np.asarray(s, dtype=np.float32).reshape(-1), sr)
+    return au
+
+
 def decode(mp3):
     out = subprocess.run(['ffmpeg', '-v', 'error', '-i', mp3, '-f', 'f32le', '-ac', '1', '-ar', str(SR), '-'], capture_output=True, check=True).stdout
     return np.frombuffer(out, dtype=np.float32).copy()
@@ -269,10 +330,11 @@ async def synth_sentence(chunks, sep=''):
         x, lead_cut = trim_edges(decode(au))
         dur = len(x) / SR
         return x, chunk_starts(text, chunks, words, lead_cut, dur, sep), dur
+    chunk_synth = {'piper': synth_piper, 'kokoro_onnx': synth_kokoro_onnx}.get(ENGINE, synth_kokoro)
     pad = np.zeros(int(CHUNK_PAD * SR), dtype=np.float32)
     parts = []; starts = []; pos = 0.0
     for i, c in enumerate(chunks):
-        xi, _ = trim_edges(decode(synth_kokoro(c)))
+        xi, _ = trim_edges(decode(chunk_synth(c)))
         if i:
             parts.append(pad); pos += len(pad) / SR
         starts.append(pos)
@@ -351,7 +413,7 @@ async def main(narr):
             print(f"    f{sb['from']} (≈{w:.0f}px{'，会折两行' if w > SUB_MAX_W * 1.3 else ''}) {sb['text']}")
     # 输出
     tl = {'fps': FPS, 'total_frames': total, 'engine': ENGINE,
-          'voice': VOICE if ENGINE == 'edge' else KOKORO_VOICE,
+          'voice': {'edge': VOICE, 'piper': PIPER_VOICE_NAME, 'kokoro_onnx': KOKORO_ONNX_VOICE}.get(ENGINE, KOKORO_VOICE),
           'rate': RATE if ENGINE == 'edge' else KOKORO_SPEED,
           'gap': GAP, 'chapter_gap': CHAPTER_GAP, 'lead': LEAD, 'tail': TAIL,
           'lang': lang, 'chapters': chapters, 'sentences': sentences, 'chars': total_chars, 'words': total_words,


### PR DESCRIPTION
# Linux / Raspberry Pi (ARM) support

Ran the skill end-to-end on a **Raspberry Pi 5 (ARM64, Debian trixie, Python 3.13)** and hit a few macOS/x86 assumptions. This PR fixes them without changing anything for existing macOS users — the new engines are opt-in via `TTS_ENGINE`, and the browser config is a no-op unless an env var is set.

## Changes

**`template/scripts/new_project.sh` — portable in-place `sed`**
`sed -i ''` is BSD/macOS syntax; on GNU sed it reads `''` as the script and `config.ts` as a filename, so scaffolding aborts. Switched to `sed -i.bak … && rm -f …bak`, which works on both.

**`template/scripts/tts_build.py` — two local TTS engines for ARM**
The default English engine (`kokoro`) won't install on ARM/Py 3.13: it pins `numpy==1.26.4` (no aarch64/py3.13 wheel → source build fails) and pulls spaCy → `blis` (no aarch64 wheel, won't compile). Added two engines that install cleanly, both slotting into the existing no-word-boundary per-chunk path, both env-driven with clear errors when unset:

- **`kokoro_onnx`** — the kokoro model via `onnxruntime` (no torch, no spaCy). Natural voice; `pip install kokoro-onnx` + two model files. Env: `KOKORO_ONNX_MODEL`, `KOKORO_ONNX_VOICES`, `KOKORO_ONNX_VOICE` (default `am_michael`).
- **`piper`** — fast, Pi-native fallback (onnxruntime VITS), lower quality. `pip install piper-tts` + a voice `.onnx`. Env: `PIPER_MODEL`.

Also updated the cache key and the timeline `voice` field to include the new engines. No change to `edge`/`kokoro` behavior.

**`template/remotion.config.ts` (new) — system Chromium on ARM**
Chrome-for-Testing has no linux-arm64 build, so Remotion can't download a browser. This file points it at a system Chromium via `REMOTION_BROWSER_EXECUTABLE` (+ optional `REMOTION_GL`, default `swangle` for GPU-less boxes). Both env vars unset on macOS/x86 → the file does nothing and Remotion uses its own browser as before.

**`README.md`** — a "Linux / Raspberry Pi (ARM)" subsection documenting the `apt` packages, the browser env var, and the TTS engine options.

## Testing
Scaffolded, voiced (kokoro_onnx `am_michael`, piper, and edge Andrew Neural), and rendered a full ~50s film on the Pi 5 via system Chromium + software GL. `npx tsc --noEmit` clean; `python3 -m py_compile scripts/tts_build.py` clean.

## Notes for the maintainer
- Comments/docstrings kept in the repo's existing zh style; happy to add a matching `README_ZH.md` section if you'd like.
- The two new engines are documented as Linux/ARM-oriented but work anywhere; they don't change the macOS defaults.
